### PR TITLE
Extend invoice accrual with support of the invoice merge module

### DIFF
--- a/account_invoice_accrual/models/account_invoice.py
+++ b/account_invoice_accrual/models/account_invoice.py
@@ -71,10 +71,11 @@ class AccountInvoice(models.Model):
 
     @api.multi
     def action_cancel(self):
-        for invoice in self:
-            if invoice.to_be_reversed:
-                raise exceptions.Warning(
-                    _('Please reverse accrual before cancelling invoice'))
+        if 'is_merge' not in self.context:  # See account_invoice_merge module
+            for invoice in self:
+                if invoice.to_be_reversed:
+                    raise exceptions.Warning(
+                        _('Please reverse accrual before cancelling invoice'))
         return super(AccountInvoice, self).action_cancel()
 
     @api.multi

--- a/account_invoice_accrual_merge/README.rst
+++ b/account_invoice_accrual_merge/README.rst
@@ -1,0 +1,44 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+=============================
+Account Invoice Accrual Merge
+=============================
+
+Allow to merge draft invoices/credit notes having an accrual. The canceled
+invoices get their accrual reversed and the new invoice get a new accrual.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/89/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/account-closing/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jacques-Etienne Baudoux <je@bcim.be>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_invoice_accrual_merge/__init__.py
+++ b/account_invoice_accrual_merge/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_invoice_accrual_merge/__manifest__.py
+++ b/account_invoice_accrual_merge/__manifest__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright Jacques-Etienne Baudoux (BCIM sprl) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Account invoice accrual merge",
+    "version": "10.0.1.0.0",
+    "author": "BCIM sprl,Odoo Community Association (OCA)",
+    "category": "Invoice",
+    "website": "http://www.bcim.be",
+    "depends": [
+        "account_invoice_accrual",
+        "account_invoice_merge",
+    ],
+    "license": "AGPL-3",
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/account_invoice_accrual_merge/models/__init__.py
+++ b/account_invoice_accrual_merge/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_invoice

--- a/account_invoice_accrual_merge/models/account_invoice.py
+++ b/account_invoice_accrual_merge/models/account_invoice.py
@@ -1,0 +1,29 @@
+# Copyright 2018 Jacques-Etienne Baudoux (BCIM sprl) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models, _
+from odoo.exceptions import UserError
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    @api.multi
+    def do_merge(self, keep_references=True, date_invoice=False,
+                 remove_empty_invoice_lines=True):
+        invoices_info = super(AccountInvoice, self).do_merge()
+        for new_invoice_id, old_invoice_ids in invoices_info.iteritems():
+            old_invoices = self.browse(old_invoice_ids)
+            to_be_reversed = old_invoices.mapped('to_be_reversed')
+            if len(to_be_reversed) > 1:
+                raise UserError(_(
+                    "You cannot merge invoices where only some of them have "
+                    "an accrual entry"))
+            elif to_be_reversed == ["True"]:
+                old_invoices.reverse_accruals()
+                new_invoice = self.browse(new_invoice_id)
+                accrual = self.env['account.move.accrue'].with_context(
+                    active_model=self._name, active_ids=new_invoice.ids)\
+                    .create()
+                accrual.action_accrue()
+        return invoices_info


### PR DESCRIPTION
Invoice accrual prevents to canceling a draft invoice having an accrual. Invoice merge module, cancel merged invoices to create a new one. This purpose of this module is to solve that issue by reversing the accrual on canceled invoices and accrue the new invoice.

WIP